### PR TITLE
Improve prefix handling to add a root_path

### DIFF
--- a/fastapi-example/app.py
+++ b/fastapi-example/app.py
@@ -16,6 +16,8 @@ async def process_valohai_prefix(request: Request, call_next):
         if not prefix:  # Could have no header or no envvar, so skip
             continue
         if path.startswith(prefix):  # If the path starts with this prefix,
+            # ... tell FastAPI (0.56.0+) that that is the prefix we're mounted under...
+            request.scope["root_path"] = prefix
             # ... then strip the prefix out as far as FastAPI is concerned.
             request.scope["path"] = "/" + path[len(prefix) :].lstrip("/")
             break


### PR DESCRIPTION
This should make FastAPI's internal routing (for e.g. /docs) work.

